### PR TITLE
Improve cmake

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -171,7 +171,7 @@ ReflowComments:  true
 RemoveBracesLLVM: false
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
-SortIncludes:    CaseSensitive
+#SortIncludes:    CaseSensitive
 SortJavaStaticImport: Before
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: update
         run: sudo apt-get update && sudo apt-get upgrade -y
       - name: install packages
-        run: sudo apt-get install -y -m -f --install-suggests build-essential git libtool libtool-bin automake bison libglib2.0-0 clang llvm-dev libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build clang-tidy clang-format
+        run: sudo apt-get install -y -m -f --install-suggests build-essential git libtool libtool-bin automake bison libglib2.0-0 clang llvm-dev libc++-dev findutils libcmocka-dev python3-dev python3-setuptools ninja-build clang-tidy clang-format libyaml-cpp-dev
       - name: Run cmake
         run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       - name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,8 @@ on:
   push:
     branches-ignore: [master, main]
     # Remove the line above to run when pushing to master
-  pull_request:
-    branches: [master, main]
+    #pull_request:
+    #branches: [master, main]
 
 ###############
 # Set the Job #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,14 +8,53 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -g -O2 -fsanitize=address")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3")
 set(LINK_FLAGS "${LINK_FLAGS} -fsanitize=address")
-
 find_package(PkgConfig)
-pkg_check_modules(MySQL REQUIRED mysqlclient>=5.7)
 
-find_package(PostgreSQL REQUIRED)
+option(ALL "Build all types of database" ON)
+option(SQLITE "Build sqlite" OFF)
+option(MYSQL "Build mysql" OFF)
+option(POSTGRESQL "Build postgresql" OFF)
+
+if(SQLITE OR MYSQL OR POSTGRESQL)
+  set(ALL OFF)
+endif()
+
+if(ALL)
+  set(SQLITE ON)
+  set(MYSQL ON)
+  set(POSTGRESQL ON)
+endif()
+
+if(SQLITE)
+  list(APPEND DBMS sqlite)
+endif()
+
+if(MYSQL)
+  list(APPEND DBMS mysql)
+  pkg_check_modules(MySQL REQUIRED mysqlclient>=5.7)
+  add_library(mysql_client OBJECT srcs/internal/client/client_mysql.cc)
+  target_include_directories(mysql_client PUBLIC ${MySQL_INCLUDE_DIRS}
+                                                srcs/internal/client)
+  target_link_libraries(mysql_client PUBLIC ${MySQL_LIBRARIES} yaml-cpp)
+  target_compile_options(mysql_client PRIVATE -fPIC)
+  list(APPEND LINK_CLIENT mysql_client)
+  list(APPEND CLIENT_DEFINITION __SQUIRREL_MYSQL__)
+endif()
+
+if(POSTGRESQL)
+  list(APPEND DBMS postgresql)
+  find_package(PostgreSQL REQUIRED)
+  add_library(postgresql_client OBJECT srcs/internal/client/client_postgresql.cc)
+  target_include_directories(postgresql_client PUBLIC ${PostgreSQL_INCLUDE_DIRS}
+                                                      srcs/internal/client)
+  target_link_libraries(postgresql_client PUBLIC ${PostgreSQL_LIBRARIES} yaml-cpp
+                                                absl::strings absl::str_format)
+  target_compile_options(postgresql_client PRIVATE -fPIC)
+  list(APPEND LINK_CLIENT postgresql_client)
+  list(APPEND CLIENT_DEFINITION __SQUIRREL_POSTGRESQL__)
+endif()
 
 include(FetchContent)
-
 FetchContent_Declare(
   yaml-cpp
   URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.zip)
@@ -31,8 +70,6 @@ string(REPLACE " -w" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 set(AFLPP_DIR ${CMAKE_CURRENT_SOURCE_DIR}/AFLplusplus/include)
 
 include_directories(${AFLPP_DIR})
-
-list(APPEND DBMS sqlite mysql postgresql)
 
 foreach(dbms IN LISTS DBMS)
   add_library(
@@ -58,6 +95,7 @@ foreach(dbms IN LISTS DBMS)
                              PRIVATE __SQUIRREL_${UPPER_CASE_DBMS}__)
 endforeach()
 
+if(MYSQL OR POSTGRESQL)
 add_executable(db_driver srcs/db_driver.cc)
 target_link_libraries(db_driver yaml-cpp all_client absl::strings
                       absl::str_format)
@@ -68,21 +106,9 @@ target_include_directories(test_client PUBLIC srcs/internal/client)
 
 add_library(all_client SHARED srcs/internal/client/client.cc)
 target_include_directories(all_client PUBLIC srcs/internal/client)
-target_link_libraries(all_client PUBLIC mysql_client postgresql_client)
-
-# MySQL client
-add_library(mysql_client OBJECT srcs/internal/client/client_mysql.cc)
-target_include_directories(mysql_client PUBLIC ${MySQL_INCLUDE_DIRS}
-                                               srcs/internal/client)
-target_link_libraries(mysql_client PUBLIC ${MySQL_LIBRARIES} yaml-cpp)
-target_compile_options(mysql_client PRIVATE -fPIC)
-
-add_library(postgresql_client OBJECT srcs/internal/client/client_postgresql.cc)
-target_include_directories(postgresql_client PUBLIC ${PostgreSQL_INCLUDE_DIRS}
-                                                    srcs/internal/client)
-target_link_libraries(postgresql_client PUBLIC ${PostgreSQL_LIBRARIES} yaml-cpp
-                                               absl::strings absl::str_format)
-target_compile_options(postgresql_client PRIVATE -fPIC)
+target_link_libraries(all_client PUBLIC ${LINK_CLIENT})
+add_compile_definitions(all_client PRIVATE ${CLIENT_DEFINITION})
+endif()
 
 add_library(config_validator OBJECT srcs/utils/config_validate.cc)
 target_link_libraries(config_validator PRIVATE yaml-cpp absl::strings absl::str_format)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ option(SQLITE "Build sqlite" OFF)
 option(MYSQL "Build mysql" OFF)
 option(POSTGRESQL "Build postgresql" OFF)
 
-if(SQLITE OR MYSQL OR POSTGRESQL)
+if(SQLITE
+   OR MYSQL
+   OR POSTGRESQL)
   set(ALL OFF)
 endif()
 
@@ -34,8 +36,9 @@ if(MYSQL)
   pkg_check_modules(MySQL REQUIRED mysqlclient>=5.7)
   add_library(mysql_client OBJECT srcs/internal/client/client_mysql.cc)
   target_include_directories(mysql_client PUBLIC ${MySQL_INCLUDE_DIRS}
-                                                srcs/internal/client)
-  target_link_libraries(mysql_client PUBLIC ${MySQL_LIBRARIES} yaml-cpp)
+                                                 srcs/internal/client)
+  target_link_libraries(mysql_client PUBLIC ${MySQL_LIBRARIES}
+                                            ${YAML_CPP_LIBRARIES})
   target_compile_options(mysql_client PRIVATE -fPIC)
   list(APPEND LINK_CLIENT mysql_client)
   list(APPEND CLIENT_DEFINITION __SQUIRREL_MYSQL__)
@@ -44,23 +47,26 @@ endif()
 if(POSTGRESQL)
   list(APPEND DBMS postgresql)
   find_package(PostgreSQL REQUIRED)
-  add_library(postgresql_client OBJECT srcs/internal/client/client_postgresql.cc)
+  add_library(postgresql_client OBJECT
+              srcs/internal/client/client_postgresql.cc)
   target_include_directories(postgresql_client PUBLIC ${PostgreSQL_INCLUDE_DIRS}
                                                       srcs/internal/client)
-  target_link_libraries(postgresql_client PUBLIC ${PostgreSQL_LIBRARIES} yaml-cpp
-                                                absl::strings absl::str_format)
+  target_link_libraries(
+    postgresql_client PUBLIC ${PostgreSQL_LIBRARIES} ${YAML_CPP_LIBRARIES}
+                             absl::strings absl::str_format)
   target_compile_options(postgresql_client PRIVATE -fPIC)
   list(APPEND LINK_CLIENT postgresql_client)
   list(APPEND CLIENT_DEFINITION __SQUIRREL_POSTGRESQL__)
 endif()
 
 include(FetchContent)
-FetchContent_Declare(
-  yaml-cpp
-  URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.zip)
-FetchContent_MakeAvailable(yaml-cpp)
+find_package(yaml-cpp REQUIRED)
+# FetchContent_Declare( ${YAML_CPP_LIBRARIES} URL
+# https://github.com/jbeder/${YAML_CPP_LIBRARIES}/archive/refs/tags/${YAML_CPP_LIBRARIES}-0.7.0.zip)
+# FetchContent_MakeAvailable(${YAML_CPP_LIBRARIES})
+include_directories(${YAML_INCLUDE_DIRS})
 
-set_target_properties(yaml-cpp PROPERTIES COMPILE_FLAGS "-w")
+# set_target_properties(${YAML_CPP_LIBRARIES} PROPERTIES COMPILE_FLAGS "-w")
 
 set(ABSL_PROPAGATE_CXX_STD ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
@@ -84,7 +90,8 @@ foreach(dbms IN LISTS DBMS)
   target_include_directories(${dbms}_impl PRIVATE srcs/internal/${dbms}/include
                                                   srcs)
   target_compile_options(${dbms}_impl PRIVATE -fPIC)
-  target_link_libraries(${dbms}_impl yaml-cpp absl::strings absl::str_format)
+  target_link_libraries(${dbms}_impl ${YAML_CPP_LIBRARIES} absl::strings
+                        absl::str_format)
 
   string(TOUPPER ${dbms} UPPER_CASE_DBMS)
   add_library(${dbms}_mutator SHARED srcs/custom_mutator.cc srcs/db_factory.cc)
@@ -96,26 +103,25 @@ foreach(dbms IN LISTS DBMS)
 endforeach()
 
 if(MYSQL OR POSTGRESQL)
-add_executable(db_driver srcs/db_driver.cc)
-target_link_libraries(db_driver yaml-cpp all_client absl::strings
-                      absl::str_format)
+  add_executable(db_driver srcs/db_driver.cc)
+  target_link_libraries(db_driver ${YAML_CPP_LIBRARIES} all_client
+                        absl::strings absl::str_format)
 
-add_executable(test_client srcs/internal/client/test_client.cc)
-target_link_libraries(test_client all_client)
-target_include_directories(test_client PUBLIC srcs/internal/client)
+  add_executable(test_client srcs/internal/client/test_client.cc)
+  target_link_libraries(test_client all_client ${YAML_CPP_LIBRARIES})
+  target_include_directories(test_client PUBLIC srcs/internal/client)
 
-add_library(all_client SHARED srcs/internal/client/client.cc)
-target_include_directories(all_client PUBLIC srcs/internal/client)
-target_link_libraries(all_client PUBLIC ${LINK_CLIENT})
-add_compile_definitions(all_client PRIVATE ${CLIENT_DEFINITION})
+  add_library(all_client SHARED srcs/internal/client/client.cc)
+  target_include_directories(all_client PUBLIC srcs/internal/client)
+  target_link_libraries(all_client PUBLIC ${LINK_CLIENT})
+  target_compile_definitions(all_client PRIVATE ${CLIENT_DEFINITION})
 endif()
 
 add_library(config_validator OBJECT srcs/utils/config_validate.cc)
-target_link_libraries(config_validator PRIVATE yaml-cpp absl::strings absl::str_format)
+target_link_libraries(config_validator PRIVATE ${YAML_CPP_LIBRARIES}
+                                               absl::strings absl::str_format)
 target_include_directories(config_validator PUBLIC srcs/utils)
 target_compile_options(config_validator PRIVATE -fPIC)
 
-
 include(lint.cmake)
 add_subdirectory(tests)
-

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 For ubuntu 22.04:
 ```
-sudo apt install libmysqlclient-dev cmake ninja-build clang pkg-config clang-format libpq-dev
+sudo apt install libmysqlclient-dev cmake ninja-build clang pkg-config clang-format libpq-dev libyaml-cpp-dev
 ```
 
 ### Build Squirrel

--- a/srcs/internal/client/client.cc
+++ b/srcs/internal/client/client.cc
@@ -3,18 +3,29 @@
 #include <cassert>
 #include <string>
 
+#ifdef __SQUIRREL_MYSQL__
 #include "client_mysql.h"
+#endif
+
+#ifdef __SQUIRREL_POSTGRESQL__
 #include "client_postgresql.h"
+#endif
+
 namespace client {
 DBClient *create_client(const std::string &db_name, const YAML::Node &config) {
   DBClient *result = nullptr;
   if (db_name == "mysql") {
+    #ifdef __SQUIRREL_MYSQL__
     result = new MySQLClient;
+    #endif
   } else if (db_name == "postgresql") {
+    #ifdef __SQUIRREL_POSTGRESQL__
     result = new PostgreSQLClient;
+    #endif
   } else {
     assert(false && "It is not supported!");
   }
+  assert(result && "It is not supported!");
 
   result->initialize(config);
   return result;

--- a/srcs/internal/client/client.cc
+++ b/srcs/internal/client/client.cc
@@ -15,13 +15,13 @@ namespace client {
 DBClient *create_client(const std::string &db_name, const YAML::Node &config) {
   DBClient *result = nullptr;
   if (db_name == "mysql") {
-    #ifdef __SQUIRREL_MYSQL__
+#ifdef __SQUIRREL_MYSQL__
     result = new MySQLClient;
-    #endif
+#endif
   } else if (db_name == "postgresql") {
-    #ifdef __SQUIRREL_POSTGRESQL__
+#ifdef __SQUIRREL_POSTGRESQL__
     result = new PostgreSQLClient;
-    #endif
+#endif
   } else {
     assert(false && "It is not supported!");
   }

--- a/srcs/internal/client/test_client.cc
+++ b/srcs/internal/client/test_client.cc
@@ -3,15 +3,15 @@
 #include <iostream>
 #include <string>
 
-#include "client_postgresql.h"
+#include "client.h"
 #include "yaml-cpp/yaml.h"
 
 int main(int argc, char **argv) {
   YAML::Node config = YAML::LoadFile(std::string(argv[1]));
 
   std::string db_name = config["db"].as<std::string>();
-  client::PostgreSQLClient *test_client = new client::PostgreSQLClient;
-  // client::DBClient *test_client = client::create_client(db_name, config);
+  // client::PostgreSQLClient *test_client = new client::PostgreSQLClient;
+  client::DBClient *test_client = client::create_client(db_name, config);
   test_client->initialize(config);
   /*
   if (test_client.connect()) {


### PR DESCRIPTION
Sperate build tart so that we don’t need to build them all.

Make yaml-cpp a preinstalled dependency.